### PR TITLE
feat: Migration from feature policy to permissions policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,10 @@
 # Changelog
 
-## 0.5.0 - 2020-04-16
+## 0.1.0 - 2020-09-25
 ### Added
-- 7 new features: `battery`, `displayCapture`, `executionWhileNotRendered`, `executionWhileOutOfViewport`, `navigationOverride`, `publickeyCredentials`, and `xrSpatialTracking`
-
-## 0.4.0 - 2019-09-01
+- Initial release containing all the adaptations of the [Feature Policy](https://github.com/helmetjs/feature-policy) project to support the new `Permissions-Policy` header.
 ### Changed
-- Drop support for Node <8
-- Duplicate values are no longer allowed. See [#4](https://github.com/helmetjs/feature-policy/issues/4)
-- Non-strings are not allowed in the array
-
-## 0.3.0 - 2019-05-05
-### Added
-- 19 new features: `ambientLightSensor`, `documentDomain`, `documentWrite`, `encryptedMedia`, `fontDisplayLateSwap`, `layoutAnimations`, `legacyImageFormats`, `loadingFrameDefaultEager`, `oversizedImages`, `pictureInPicture`, `serial`, `syncScript`, `unoptimizedImages`, `unoptimizedLosslessImages`, `unoptimizedLossyImages`, `unsizedMedia`, `verticalScroll`, `wakeLock`, and `xr`
-- TypeScript definitions. See [#2](https://github.com/helmetjs/feature-policy/issues/2) and [helmet#188](https://github.com/helmetjs/helmet/issues/188)
-- Created a changelog
-
-### Changed
-- Updated some package metadata
-
-Changes in versions 0.2.0 and below can be found in [Helmet's changelog](https://github.com/helmetjs/helmet/blob/master/CHANGELOG.md).
+- Initial release containing all the adaptations of the [Feature Policy](https://github.com/helmetjs/feature-policy) project to support the new `Permissions-Policy` header.
+- If you're migrating from that repo make note that for now on the reserved keywords don't need to be quoted but the specific feature values must be.
+- Added errors to safeguard the usage with the newest changes.
+- Reviewed all the tests.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018-2020 Evan Hahn
+Copyright (c) 2020 Pedro Fernandes
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 Feature Policy
 ==============
-[![Build Status](https://travis-ci.org/helmetjs/feature-policy.svg?branch=master)](https://travis-ci.org/helmetjs/feature-policy)
+[![Build Status](https://travis-ci.org/pedro-gbf/permissions-policy.svg?branch=master)](https://travis-ci.org/pedro-gbf/permissions-policy)
 
-**NOTE: The `Feature-Policy` header has been deprecated by browsers in favor of `Permissions-Policy`. This module will still be supported but no new features will be added.**
+**NOTE: Since the `Feature-Policy` header was deprecated I've decided to adapt the old Evan Hahn `Permissions-Policy` repositoy and adapt it to support it, this project was entirely built on top of his work.**
 
-This is Express middleware to set the `Feature-Policy` header. You can read more about it [here](https://scotthelme.co.uk/a-new-security-header-feature-policy/) and [here](https://developers.google.com/web/updates/2018/06/feature-policy).
+This is Express middleware to set the `Permissions-Policy` header. You can read more about it [here](https://www.w3.org/TR/permissions-policy-1/).
 
 To use:
 
 ```javascript
-const featurePolicy = require('feature-policy')
+const permissionsPolicy = require('permissions-policy')
 
 // ...
 
-app.use(featurePolicy({
+app.use(permissionsPolicy({
   features: {
-    fullscreen: ["'self'"],
-    vibrate: ["'none'"],
-    payment: ['example.com'],
-    syncXhr: ["'none'"]
+    fullscreen: ['self'],
+    vibrate: ['none'],
+    payment: ['"example.com"'],
+    syncXhr: ['none']
   }
 }))
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "feature-policy",
+  "name": "permissions-policy",
   "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "feature-policy",
-  "author": "Evan Hahn <me@evanhahn.com> (https://evanhahn.com)",
-  "description": "Middleware to set the Feature-Policy HTTP header",
-  "version": "0.5.0",
+  "name": "permissions-policy",
+  "author": "Pedro Fernandes <pedrogbfernandes@gmail.com>",
+  "description": "Middleware to set the Permissions-Policy HTTP header",
+  "version": "0.0.0",
   "license": "MIT",
   "keywords": [
     "helmet",
     "security",
     "express",
     "connect",
-    "feature-policy"
+    "permissions-policy"
   ],
-  "homepage": "https://github.com/helmetjs/feature-policy",
+  "homepage": "https://github.com/pedro-gbf/permissions-policy",
   "repository": {
     "type": "git",
-    "url": "git://github.com/helmetjs/feature-policy.git"
+    "url": "git://github.com/pedro-gbf/permissions-policy.git"
   },
   "bugs": {
-    "url": "https://github.com/helmetjs/feature-policy/issues",
-    "email": "me@evanhahn.com"
+    "url": "https://github.com/pedro-gbf/permissions-policy/issues",
+    "email": "pedrogbfernandes@gmail.com"
   },
   "scripts": {
     "pretest": "npm run lint",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,7 +3,7 @@ import request from 'supertest';
 import dashify from 'dashify';
 import { IncomingMessage, ServerResponse } from 'http';
 
-import featurePolicy = require('..')
+import permissionsPolicy = require('..')
 
 const ALLOWED_FEATURE_NAMES = [
   'accelerometer',
@@ -51,7 +51,7 @@ const ALLOWED_FEATURE_NAMES = [
   'xrSpatialTracking',
 ];
 
-function app (middleware: ReturnType<typeof featurePolicy>): connect.Server {
+function app (middleware: ReturnType<typeof permissionsPolicy>): connect.Server {
   const result = connect();
   result.use(middleware);
   result.use((_req: IncomingMessage, res: ServerResponse) => {
@@ -60,25 +60,25 @@ function app (middleware: ReturnType<typeof featurePolicy>): connect.Server {
   return result;
 }
 
-describe('featurePolicy', () => {
+describe('permissionsPolicy', () => {
   it('fails without at least 1 feature', () => {
     /* eslint-disable @typescript-eslint/no-explicit-any */
-    expect(featurePolicy.bind(null)).toThrow();
-    expect(featurePolicy.bind(null, {} as any)).toThrow();
-    expect(featurePolicy.bind(null, { features: null } as any)).toThrow();
-    expect(featurePolicy.bind(null, { features: {} } as any)).toThrow();
+    expect(permissionsPolicy.bind(null)).toThrow();
+    expect(permissionsPolicy.bind(null, {} as any)).toThrow();
+    expect(permissionsPolicy.bind(null, { features: null } as any)).toThrow();
+    expect(permissionsPolicy.bind(null, { features: {} } as any)).toThrow();
     /* eslint-enable @typescript-eslint/no-explicit-any */
   });
 
   it('fails with features outside the allowlist', () => {
-    expect(featurePolicy.bind(null, {
+    expect(permissionsPolicy.bind(null, {
       features: { garbage: ['*'] },
     })).toThrow();
   });
 
   it("fails if a feature's value is not an array", () => {
     [
-      "'self'",
+      'self',
       null,
       undefined,
       123,
@@ -89,7 +89,7 @@ describe('featurePolicy', () => {
         '0': '*',
       },
     ].forEach((value) => {
-      expect(featurePolicy.bind(null, {
+      expect(permissionsPolicy.bind(null, {
         features: { vibrate: value as any }, // eslint-disable-line @typescript-eslint/no-explicit-any
       })).toThrow();
     });
@@ -97,90 +97,90 @@ describe('featurePolicy', () => {
 
   it("fails if a feature's value is an array with a non-string", () => {
     /* eslint-disable @typescript-eslint/no-explicit-any */
-    expect(featurePolicy.bind(null, {
+    expect(permissionsPolicy.bind(null, {
       features: { vibrate: ['example.com', null] as any },
     })).toThrow();
-    expect(featurePolicy.bind(null, {
+    expect(permissionsPolicy.bind(null, {
       features: { vibrate: ['example.com', 123] as any },
     })).toThrow();
-    expect(featurePolicy.bind(null, {
+    expect(permissionsPolicy.bind(null, {
       features: { vibrate: [new String('example.com')] as any }, // eslint-disable-line no-new-wrappers
     })).toThrow();
     /* eslint-enable @typescript-eslint/no-explicit-any */
   });
 
-  it('fails if "self" or "none" are not quoted', () => {
-    expect(featurePolicy.bind(null, {
-      features: { vibrate: ['self'] },
+  it('fails if "self" or if "none" are quoted', () => {
+    expect(permissionsPolicy.bind(null, {
+      features: { vibrate: ["'self'"] },
     })).toThrow();
-    expect(featurePolicy.bind(null, {
-      features: { vibrate: ['none'] },
+    expect(permissionsPolicy.bind(null, {
+      features: { vibrate: ["'none'"] },
     })).toThrow();
   });
 
   it("fails if a feature's value is an empty array", () => {
-    expect(featurePolicy.bind(null, {
+    expect(permissionsPolicy.bind(null, {
       features: { vibrate: [] },
     })).toThrow();
   });
 
   it('fails if a feature value contains "*" and additional values', () => {
-    expect(featurePolicy.bind(null, {
+    expect(permissionsPolicy.bind(null, {
       features: { vibrate: ['*', 'example.com'] },
     })).toThrow();
-    expect(featurePolicy.bind(null, {
+    expect(permissionsPolicy.bind(null, {
       features: { vibrate: ['example.com', '*'] },
     })).toThrow();
   });
 
   it('fails if a feature value contains "none" and additional values', () => {
-    expect(featurePolicy.bind(null, {
+    expect(permissionsPolicy.bind(null, {
       features: { vibrate: ["'none'", 'example.com'] },
     })).toThrow();
-    expect(featurePolicy.bind(null, {
+    expect(permissionsPolicy.bind(null, {
       features: { vibrate: ['example.com', "'none'"] },
     })).toThrow();
   });
 
   it('fails if a feature value contains duplicates', () => {
-    expect(featurePolicy.bind(null, {
+    expect(permissionsPolicy.bind(null, {
       features: { vibrate: ['example.com', 'example.com'] },
     })).toThrow();
   });
 
   it('can set "vibrate" to "*"', () => {
-    return request(app(featurePolicy({
+    return request(app(permissionsPolicy({
       features: { vibrate: ['*'] },
     })))
       .get('/')
-      .expect('Feature-Policy', 'vibrate *')
-      .expect('Hello world!');
+      .expect('Permissions-Policy', 'vibrate=(*)')
+      .expect('Hello world!'); 
   });
 
   it('can set "vibrate" to "self"', () => {
-    return request(app(featurePolicy({
-      features: { vibrate: ["'self'"] },
+    return request(app(permissionsPolicy({
+      features: { vibrate: ['self'] },
     })))
       .get('/')
-      .expect('Feature-Policy', "vibrate 'self'")
+      .expect('Permissions-Policy', "vibrate=(self)")
       .expect('Hello world!');
   });
 
   it('can set "vibrate" to "none"', () => {
-    return request(app(featurePolicy({
-      features: { vibrate: ["'none'"] },
+    return request(app(permissionsPolicy({
+      features: { vibrate: ["none"] },
     })))
       .get('/')
-      .expect('Feature-Policy', "vibrate 'none'")
+      .expect('Permissions-Policy', "vibrate=(none)")
       .expect('Hello world!');
   });
 
   it('can set "vibrate" to contain domains', () => {
-    return request(app(featurePolicy({
-      features: { vibrate: ['example.com', 'evanhahn.com'] },
+    return request(app(permissionsPolicy({
+      features: { vibrate: ['"example.com"', '"evanhahn.com"'] },
     })))
       .get('/')
-      .expect('Feature-Policy', 'vibrate example.com evanhahn.com')
+      .expect('Permissions-Policy', 'vibrate=("example.com" "evanhahn.com")')
       .expect('Hello world!');
   });
 
@@ -188,42 +188,42 @@ describe('featurePolicy', () => {
     return Promise.all(ALLOWED_FEATURE_NAMES.map(feature => {
       const features = { [feature]: ['*'] };
 
-      return request(app(featurePolicy({ features })))
+      return request(app(permissionsPolicy({ features })))
         .get('/')
-        .expect('Feature-Policy', `${dashify(feature) } *`)
+        .expect('Permissions-Policy', `${dashify(feature) }=(*)`)
         .expect('Hello world!');
     }));
   });
 
   it('can set all values in the allowlist to "self"', () => {
     return Promise.all(ALLOWED_FEATURE_NAMES.map(feature => {
-      const features = { [feature]: ["'self'"] };
+      const features = { [feature]: ['self'] };
 
-      return request(app(featurePolicy({ features })))
+      return request(app(permissionsPolicy({ features })))
         .get('/')
-        .expect('Feature-Policy', `${dashify(feature) } 'self'`)
+        .expect('Permissions-Policy', `${dashify(feature) }=(self)`)
         .expect('Hello world!');
     }));
   });
 
   it('can set all values in the allowlist to "none"', () => {
     return Promise.all(ALLOWED_FEATURE_NAMES.map(feature => {
-      const features = { [feature]: ["'none'"] };
+      const features = { [feature]: ["none"] };
 
-      return request(app(featurePolicy({ features })))
+      return request(app(permissionsPolicy({ features })))
         .get('/')
-        .expect('Feature-Policy', `${dashify(feature) } 'none'`)
+        .expect('Permissions-Policy', `${dashify(feature) }=(none)`)
         .expect('Hello world!');
     }));
   });
 
   it('can set all values in the allowlist to domains', () => {
     return Promise.all(ALLOWED_FEATURE_NAMES.map(feature => {
-      const features = { [feature]: ['example.com', 'evanhahn.com'] };
+      const features = { [feature]: ['"example.com"', '"evanhahn.com"'] };
 
-      return request(app(featurePolicy({ features })))
+      return request(app(permissionsPolicy({ features })))
         .get('/')
-        .expect('Feature-Policy', `${dashify(feature)} example.com evanhahn.com`)
+        .expect('Permissions-Policy', `${dashify(feature)}=("example.com" "evanhahn.com")`)
         .expect('Hello world!');
     }));
   });
@@ -231,28 +231,28 @@ describe('featurePolicy', () => {
   it('can set everything all at once', async () => {
     const features = ALLOWED_FEATURE_NAMES.reduce((result, feature) => ({
       ...result,
-      [feature]: [`${feature}.example.com`],
+      [feature]: [`"${feature}.example.com"`],
     }), {});
 
-    const response = await request(app(featurePolicy({ features })))
+    const response = await request(app(permissionsPolicy({ features })))
       .get('/')
       .expect('Hello world!');
 
-    const actualFeatures = response.get('feature-policy').split(';');
+    const actualFeatures = response.get('Permissions-Policy').split(', ');
     const actualFeaturesSet = new Set(actualFeatures);
 
     expect(actualFeatures).toHaveLength(actualFeaturesSet.size);
     expect(actualFeatures).toHaveLength(ALLOWED_FEATURE_NAMES.length);
 
     ALLOWED_FEATURE_NAMES.forEach((feature) => {
-      const expectedStr = `${dashify(feature)} ${feature}.example.com`;
+      const expectedStr = `${dashify(feature)}=("${feature}.example.com")`;
       expect(actualFeaturesSet.has(expectedStr)).toBeTruthy();
     });
   });
 
   it('names its function and middleware', () => {
-    expect(featurePolicy.name).toBe('featurePolicy');
-    expect(featurePolicy.name).toBe(featurePolicy({
+    expect(permissionsPolicy.name).toBe('permissionsPolicy');
+    expect(permissionsPolicy.name).toBe(permissionsPolicy({
       features: { vibrate: ['*'] },
     }).name);
   });


### PR DESCRIPTION
This includes changes in the api being used (now the reserved keywords don't need quotations but the values do), tests and the format that the header uses the feature values.