### PR TITLE
feat: Allow features to have a empty array

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,9 @@
+# Enter a short summary (100-characters or less).
+
+# Enter a longer 72-character wrapped description. This should answer:
+#
+#  - Why was this change necessary?
+#  - How does it address the problem?
+#  - Are there any side effects?
+#
+# Include a reference to the ticket if one exists.

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - "10"
   - "12"
+  - "14"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,21 @@
 # Changelog
 
+## 0.2.0 - 2020-09-27
+
+### Added
+- Features support empty arrays to indicate that the specific feature should be disable in every case.
+### Changed
+- **BREAKING-CHANGE** Removed support for Node < 10.
+
+
+## 0.1.1 - 2020-09-25
+### Changed
+- Fixed the readme typos.
+
 ## 0.1.0 - 2020-09-25
 ### Added
 - Initial release containing all the adaptations of the [Feature Policy](https://github.com/helmetjs/feature-policy) project to support the new `Permissions-Policy` header.
 ### Changed
-- Initial release containing all the adaptations of the [Feature Policy](https://github.com/helmetjs/feature-policy) project to support the new `Permissions-Policy` header.
-- If you're migrating from that repo make note that for now on the reserved keywords don't need to be quoted but the specific feature values must be.
+- If you're migrating from the [Feature Policy](https://github.com/helmetjs/feature-policy) repo make note that for now on the reserved keywords don't need to be quoted but the specific feature values must be.
 - Added errors to safeguard the usage with the newest changes.
 - Reviewed all the tests.

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ const permissionsPolicy = require('permissions-policy')
 
 app.use(permissionsPolicy({
   features: {
-    fullscreen: ['self'],
-    vibrate: ['none'],
-    payment: ['"example.com"'],
-    syncXhr: ['none']
+    fullscreen: ['self'],               // fullscreen=()
+    vibrate: ['none'],                  // vibrate=(none)
+    payment: ['self', '"example.com"'], // payment=(self "example.com")
+    syncXhr: [],                        // syncXhr=()
   }
 }))
 ```

--- a/index.ts
+++ b/index.ts
@@ -84,8 +84,8 @@ function getHeaderValueFromOptions(options: unknown): string {
       throw new Error(`permissionsPolicy does not support the "${ featureKeyCamelCase }" feature.`);
     }
 
-    if (!Array.isArray(featureValue) || featureValue.length === 0) {
-      throw new Error(`The value of the "${featureKeyCamelCase}" feature must be a non-empty array of strings.`);
+    if (!Array.isArray(featureValue)) {
+      throw new Error(`The value of the "${featureKeyCamelCase}" feature must be array of strings.`);
     }
 
     const allowedValuesSeen: Set<string> = new Set();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "permissions-policy",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "permissions-policy",
   "author": "Pedro Fernandes <pedrogbfernandes@gmail.com>",
   "description": "Middleware to set the Permissions-Policy HTTP header",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "keywords": [
     "helmet",
@@ -29,7 +29,7 @@
     "build": "npm run clean && tsc"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -118,12 +118,6 @@ describe('permissionsPolicy', () => {
     })).toThrow();
   });
 
-  it("fails if a feature's value is an empty array", () => {
-    expect(permissionsPolicy.bind(null, {
-      features: { vibrate: [] },
-    })).toThrow();
-  });
-
   it('fails if a feature value contains "*" and additional values', () => {
     expect(permissionsPolicy.bind(null, {
       features: { vibrate: ['*', 'example.com'] },
@@ -174,6 +168,16 @@ describe('permissionsPolicy', () => {
       .expect('Permissions-Policy', "vibrate=(none)")
       .expect('Hello world!');
   });
+
+  fit('can set "vibrate" as emtpy (disabled)', () => {
+    return request(app(permissionsPolicy({
+      features: { vibrate: [] },
+    })))
+      .get('/')
+      .expect('Permissions-Policy', "vibrate=()")
+      .expect('Hello world!');
+  });
+
 
   it('can set "vibrate" to contain domains', () => {
     return request(app(permissionsPolicy({


### PR DESCRIPTION
Now you can disable the array by only declaring it with an empty array.
This allows the users to declare the header as the following example:

`Permissions-Policy: microphone()` which disables the microphone for all domains.

The readme and tests were also updated to explain this new configuration.