### PR TITLE
Export ES6 code to save bytes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
     "noUnusedParameters": true,
     "outDir": "./dist",
     "strict": true,
-    "target": "es5"
+    "target": "es6"
   }
 }


### PR DESCRIPTION
Thanks for making this package!

This module targets Node 10+ which supports ECMAScript 6 features. As a minor improvement, we can compile to ES6 instead of ES5. This saves 78 bytes from the built `index.js` and makes the compiled output a bit more readable.

I didn't update the changelog because this is not a change that affects users in a meaningful way.

[Here's what the diff of the compiled file looks like.][0]

If you're interested in collaborating more broadly on this module and/or eventually integrating it into Helmet, please email me at <me@evanhahn.com> or [contact me another way](https://evanhahn.com/contact).

[0]: https://gist.github.com/EvanHahn/a5e80c1c0f9ae66581f745eab74da823