### PR TITLE
Remove unused mocha.opts file

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,0 @@
---check-leaks --exit --throw-deprecation --forbid-only --forbid-pending


### PR DESCRIPTION
In the original version of this module (Feature-Policy), I switched from Mocha to Jest but forgot to remove the `mocha.opts` file. This change removes it.