### PR TITLE
chore: Add policy to readme and remove dashify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # Changelog
 
-## Unreleased
+## 0.6.0 - 2021-04-19
 
 ### Changed
 
-- Removed restrictions on which directives can be set; any key is allowed
+- Removed restrictions on which directives can be set, any key is allowed.
+- Added interest-cohort to the documentation.
+
+## 0.5.0 - 2021-04-14
+
+### Added
+
+- Added support for interest-cohort policy.
+- Change compilation target to ES6.
 
 ## 0.4.0 - 2021-03-2
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following features are currently supported:
 - `fullscreen`
 - `geolocation`
 - `gyroscope`
+- `interestCohort`
 - `layoutAnimations`
 - `legacyImageFormats`
 - `loadingFrameDefaultEager`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "permissions-policy",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -796,12 +796,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.1.tgz",
       "integrity": "sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==",
-      "dev": true
-    },
-    "@types/dashify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/dashify/-/dashify-1.0.0.tgz",
-      "integrity": "sha512-uyYom3SM48jvowobcby+1z3r/sDX+5N8lAdPoNLKYMhF819pNjV6K5g8lAUGrwj80n+P7Qf10GcA9h7aIO2GJw==",
       "dev": true
     },
     "@types/eslint-visitor-keys": {
@@ -1643,12 +1637,6 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
-    },
-    "dashify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dashify/-/dashify-2.0.0.tgz",
-      "integrity": "sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A==",
-      "dev": true
     },
     "data-urls": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "Evan Hahn <me@evanhahn.com> (https://evanhahn.com)"
   ],
   "description": "Middleware to set the Permissions-Policy HTTP header",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "license": "MIT",
   "keywords": [
     "helmet",
@@ -49,13 +49,11 @@
   "dependencies": {},
   "devDependencies": {
     "@types/connect": "^3.4.34",
-    "@types/dashify": "^1.0.0",
     "@types/jest": "^26.0.20",
     "@types/supertest": "^2.0.10",
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",
     "connect": "^3.7.0",
-    "dashify": "^2.0.0",
     "eslint": "^7.21.0",
     "eslint-config-helmet": "^0.2.0",
     "jest": "^26.6.3",


### PR DESCRIPTION
* Reviews the changelog.md
* Removes `dashify` and `@types/dashify` since they're no longer in use
* Review the readme to reference the new policy `interestCohort`